### PR TITLE
feat: enable auto-merge with renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "extends": [
+    "config:recommended",
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5",
+  ],
+  "labels": ["kind/enhancement"],
+  "separateMinorPatch": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+  ],
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Renables renovate with auto-merge (see [alpine-conntrack](https://github.com/gardener/alpine-conntrack/pull/34) for the same treatment
- Once merged and [enabled](https://github.com/gardener/ci-infra/blob/master/deploy/renovate/renovate.yaml#L82) we can remove dependabot safely
 
**Which issue(s) this PR fixes**:
Fixes manual approval for patch version updates

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
